### PR TITLE
Fix TZif v1 data block length calculation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -557,6 +557,28 @@ mod tests {
     }
 
     #[test]
+    fn parse_valid_contents() {
+        let contents: Vec<&[u8]> = vec![
+            // #0
+            b"TZif2\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x01\0\0\0\x01\0\0\0\0\0\0\0\0\0\0\0\x01\0\0\0\x04\0\0\0\0\0\0UTC\0\0\0\
+              TZif2\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x01\0\0\0\x01\0\0\0\0\0\0\0\x01\0\0\0\x01\0\0\0\x04\xF8\0\0\0\0\0\0\0\0\0\0\0\0\0\0UTC\0\0\0\nUTC0\n",
+
+            // #1
+            b"TZif2\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x01\0\0\0\x04\0\0\0\0\0\0UTC\0\
+              TZif2\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x01\0\0\0\x04\0\0\0\0\0\0UTC\0\nUTC0\n",
+        ];
+
+        for (i, content) in contents.into_iter().enumerate() {
+            assert!(
+                Tz::parse("__valid__", content).is_ok(),
+                "test #{}: should be able to parse {:x?}",
+                i,
+                content
+            );
+        }
+    }
+
+    #[test]
     fn parse_invalid_contents() {
         let contents: Vec<(&[u8], Error)> = vec![
             (


### PR DESCRIPTION
I was trying to use this crate, but it wasn't working and the tests were failing on some of my systems.

I looked at [RFC 8536], and fixed a few issues, and now the tests pass for me, both on the system where it worked and where it didn't.

1. I made it so isstdcnt/isgmtcnt can be 0:
> isutcnt:  A four-octet unsigned integer specifying the number of UT/
>       local indicators contained in the data block -- MUST **either be
>       zero** or equal to "typecnt".

> isstdcnt:  A four-octet unsigned integer specifying the number of
>       standard/wall indicators contained in the data block -- MUST
>       **either be zero** or equal to "typecnt".

2. Updated the version 1 data block length calculation to match the description:
```
   The data block is structured as follows (the lengths of multi-octet
   fields are shown in parentheses):

        +---------------------------------------------------------+
        |  transition times          (timecnt x TIME_SIZE)        |
        +---------------------------------------------------------+
        |  transition types          (timecnt)                    |
        +---------------------------------------------------------+
        |  local time type records   (typecnt x 6)                |
        +---------------------------------------------------------+
        |  time zone designations    (charcnt)                    |
        +---------------------------------------------------------+
        |  leap-second records       (leapcnt x (TIME_SIZE + 4))  |
        +---------------------------------------------------------+
        |  standard/wall indicators  (isstdcnt)                   |
        +---------------------------------------------------------+
        |  UT/local indicators       (isutcnt)                    |
        +---------------------------------------------------------+
```

[RFC 8536]: https://tools.ietf.org/html/rfc8536