### PR TITLE
Respect TZDIR variable

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -493,8 +493,9 @@ impl Tz {
 
     /// Reads and parses a system time zone.
     ///
-    /// This function is equivalent to reading `/usr/share/zoneinfo/{name}` and
-    /// the constructs a time zone via [`parse()`](Tz::parse).
+    /// This function is equivalent to reading `$TZDIR/{name}` if the environment variable `$TZDIR`
+    /// is set or `/usr/share/zoneinfo/{name}` if it isn't, then constructing a time zone via
+    /// [`parse()`](Tz::parse).
     ///
     /// This function is currently only supported on Unix.
     #[cfg(unix)]
@@ -502,7 +503,10 @@ impl Tz {
         if name.contains('.') {
             return Err(Error::InvalidTimeZoneFileName.into());
         }
-        let content = read(format!("/usr/share/zoneinfo/{}", name))?;
+        let mut path = env::var_os("TZDIR").unwrap_or_else(|| "/usr/share/zoneinfo".into());
+        path.push("/");
+        path.push(&name);
+        let content = read(path)?;
         Ok(Self::parse(name, &content)?)
     }
 


### PR DESCRIPTION
Fixes #6

I tried to implement it similar to [time/tzfile.c:144 in glibc](https://sourceware.org/git/?p=glibc.git;a=blob;f=time/tzfile.c;h=190a777152b31cee5d90d2dc6bc784cd2c904d97;hb=268d812c19ef30b2f9d52dc517c27a349df25ca9#l144), but I'm not sure it's correct since this is the first time I ever looked at the glibc source.